### PR TITLE
Fix small problem in responsive design

### DIFF
--- a/kytos_sphinx_theme/kytos/static/kytos-sphinx.css_t
+++ b/kytos_sphinx_theme/kytos/static/kytos-sphinx.css_t
@@ -132,7 +132,7 @@ div.content {
 }
 
 #kytos-theme-content-container div.figure {
-  float: left;
+  float: none;
 }
 
 #kytos-theme-content-container .highlight {


### PR DESCRIPTION
Today, the theme has a small problem when rendering a variety of screen sizes.
This commit solves this problem by updating the responsive design.

Fix #13 

Problem:
- Text in the right.
![old](https://user-images.githubusercontent.com/10928556/87590482-36479180-c6bd-11ea-90a2-ca2c2df17fa7.jpg)

Solution:
![new](https://user-images.githubusercontent.com/10928556/87590499-40699000-c6bd-11ea-8e36-3045d3a69a97.jpg)

