### PR TITLE
Update sphinx-build from v2.0.1 to v3.2.1

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,7 +27,7 @@ requests==2.23.0          # via sphinx
 six==1.14.0               # via livereload, packaging
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autobuild==0.7.1   # via -r requirements/dev.in, kytos-sphinx-theme
-sphinx==2.0.1             # via -r requirements/dev.in, kytos-sphinx-theme
+sphinx==3.2.1             # via -r requirements/dev.in, kytos-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx


### PR DESCRIPTION
In order to solve warnings pointed in https://github.com/kytos/sphinx-theme/issues/16 issue, the sphinx-build version should be updated to v3.2.1 